### PR TITLE
Modify CLI options to choose, whether to mine for passwds or not

### DIFF
--- a/swap_digger.sh
+++ b/swap_digger.sh
@@ -93,6 +93,14 @@ function init () {
     [ $SWAP_PATH ] &&  ! [ -e "$SWAP_PATH" ] && { error "Invalid path for swap file!"; exit 1; }
     ! [ -d "$TARGET_ROOT_DIR" ] && { error "Invalid path for root directory!"; exit 1; }
 
+    # Check, that an action was specified (search, passwd retrieval or application data mining)
+    [ -z $SWAP_SEARCH ] && [ -z $PASSWD ] && [ -z $APPLICATION_DATA ] && {
+	error "Specify one of the following actions:"
+	echo -e "   \033[40m\033[1;31m  -S   search for swap devices!"
+	echo -e "     -a   mine for application data "
+	echo -e "     -p   mine for system passwds "  >&2
+	exit 1
+    }
 }
 
 function end () {
@@ -624,17 +632,16 @@ function swap_digger () {
     swap_dump_size=`ls -lh $swap_dump_path | cut -d " "  -f 5`
     [ $VERBOSE ] && out "    [-] Swap dump size: $swap_dump_size"
     # Let the fun begin!
-    dig_unix_passwd
-    [ $EXTENDED ] && {
-        dig_web_info
-        dig_xml
-        dig_wifi_info
-        dig_keepass
-        dig_history
-        dig_hashes
+    [ $PASSWD ] && dig_unix_passwd
+    [ $APPLICATION_DATA ] && {
+	dig_web_info
+	dig_xml
+	dig_wifi_info
+	dig_keepass
+	dig_history
+	dig_hashes
     }
     [ $GUESSING ] && guessing
-
 }
 
 
@@ -678,25 +685,28 @@ function swap_search () {
 # display_usage function
 display_usage ()
 {
-	echo "Searches for credentials and other sensitive data in Linux SWAP memory."
-	echo "Usage: $0 [ OPTIONS ]"
-	echo "Options : "
-	echo "  -x, --extended  Run extended tests on the target swap to retrieve other interesting data"
-	echo "		(web passwords, emails, wifi creds, most accessed urls, etc)"
-    echo "  -g, --guessing  Try to guess potential passwords based on observations and stats"
-	echo "		Warning: This option is not reliable, it may dig more passwords as well as hundreds false positives."
-	echo "  -h, --help	Display this help."
-    echo "  -v, --verbose	Verbose mode."
-    echo "  -l, --log	Log all outputs in a log file (protected inside the generated working directory)."
-    echo "  -c, --clean Automatically erase the generated working directory at end of script (will also remove log file)"
+    echo "Searches for valuable and sensitive data in Linux SWAP memory."
+    echo "Usage: $0 [ OPTIONS ]"
+    echo
+    echo "Options : "
+    echo "  -p, --passwd                Search for system passwords"
+    echo "  -g, --guessing              Try to guess potential passwords based on observations and stats."
+    echo "                              hundreds false positives. (Warning: This option is not reliable, "
+    echo "                              it may dig more passwords as well as "
+    echo "  -a, --app-data              Run extended tests on the target swap to retrieve other interesting data"
+    echo "                              (web passwords, emails, wifi creds, most accessed URLs, hashes etc)"
+    echo "  -v, --verbose               Verbose mode."
+    echo "  -l, --log                   Log all outputs in a log file (protected inside the generated working directory)."
+    echo "  -c, --clean                 Automatically erase the generated working directory at end of script (will also remove log file)"
     echo "  -r PATH, --root-path PATH   Location of the target file-system root (default value is /)"
-	echo "		Change this value for forensic analysis when target is a mounted file system."
-    echo "		This option has to  be used along the -s option to indicate path to swap device."
+    echo "                              Change this value for forensic analysis when target is a mounted file system."
+    echo "                              This option has to  be used along the -s option to indicate path to swap device."
     echo "  -s PATH, --swap-path PATH   Location of swap device or swap dump to analyse"
-    echo "		Use this option for forensic/remote analysis of a swap dump or a mounted external swap partition."
-    echo "		This option should be used with the -r option where at least /<root-path>/etc/shadow exists."
-    echo "  -S, --swap-search   Search for all available swap devices (use for forensics)."
-	echo
+    echo "                              Use this option for forensic/remote analysis of a swap dump or a mounted external swap partition."
+    echo "                              This option should be used with the -r option where at least /<root-path>/etc/shadow exists."
+    echo "  -S, --swap-search           Search for all available swap devices."
+    echo "  -h, --help                  Display this help."
+    echo
     echo "  For more details see the README.md file at https://github.com/sevagas/swap_digger"
     echo
 }
@@ -709,9 +719,10 @@ for arg in "$@"; do
   shift
   case "$arg" in
     "--clean") set -- "$@" "-c" ;;
-    "--extended") set -- "$@" "-x" ;;
+    "--app-data") set -- "$@" "-x" ;;
     "--guessing") set -- "$@" "-g" ;;
     "--log") set -- "$@" "-l" ;;
+    "--passwd") set -- "$@" "-p" ;;
     "--help") set -- "$@" "-h" ;;
     "--verbose") set -- "$@" "-v" ;;
     "--root-path") set -- "$@" "-r" ;;
@@ -724,20 +735,21 @@ done
 
 # Parse short options
 OPTIND=1
-while getopts "cxglhvS-r:s:" OPT
+while getopts "acglphvS-r:s:" OPT
 do
-   # options processing
-	case $OPT in
-        c) CLEAN=1 ;;
-        l) LOG=1 ;;
-        r) TARGET_ROOT_DIR="$OPTARG" ;;
-        s) SWAP_PATH="$OPTARG" ;;
-		x) EXTENDED=1 ;;
-        g) GUESSING=1 ;;
-		h) display_usage | more;  exit 3  ;;
-		v) VERBOSE=1 ;;
-        S) SWAP_SEARCH=1 ;;
-		*) display_usage; exit 1 ;;
+    # options processing
+    case $OPT in
+	c) CLEAN=1 ;;
+	g) GUESSING=1 ;;
+	l) LOG=1 ;;
+	p) PASSWD=1 ;;
+	r) TARGET_ROOT_DIR="$OPTARG" ;;
+	s) SWAP_PATH="$OPTARG" ;;
+	a) APPLICATION_DATA=1 ;;
+	h) display_usage | more;  exit 3  ;;
+	v) VERBOSE=1 ;;
+	S) SWAP_SEARCH=1 ;;
+	*) display_usage; exit 1 ;;
 	esac
 done
 shift $(expr $OPTIND - 1) # remove options from positional parameters


### PR DESCRIPTION
Dear Emeric, 

this PR modifies the CLI options to choose, whether to mine for system passwords or not. 

This change is especially helpful to make `swap_digger` a better suited tool for forensics investigations, where investigators are often only interested in the extraction of application data from swap space and not so much in retrieving system passwords. 

Therefore this PR adds the CLI option `--passwd` and changes the CLI option  `--extended` to `--app-data`. Furthermore a check is incorporated, to determine, whether at least one of the actions `-S`, `--passwd` or `--app-data` is specified by the user. 

Please consider this PR, since I think, that this addition makes `swap_digger` a more valuable tool for the forensics-community. 

Thank you already in advance! 

Best regards  
    Jan   

 